### PR TITLE
Final update for 1.01

### DIFF
--- a/RAS_Inventory_V1.ps1
+++ b/RAS_Inventory_V1.ps1
@@ -3,9 +3,9 @@
 
 <#
 .SYNOPSIS
-	Creates a complete inventory of Parallels Remote Application Server.
+	Creates a complete inventory of a V17 Parallels Remote Application Server.
 .DESCRIPTION
-	Creates a complete inventory of Parallels Remote Application Server (RAS) using 
+	Creates a complete inventory of a V17 Parallels Remote Application Server (RAS) using 
 	Microsoft PowerShell, Word, plain text, or HTML.
 	
 	The script requires at least PowerShell version 3 but runs best in version 5.
@@ -13,7 +13,7 @@
 	Word is NOT needed to run the script. This script outputs in Text and HTML.
 	The default output format is HTML.
 	
-	Creates an output file named RASInventory.<fileextension>.
+	Creates an output file named Parallels_RAS.<fileextension>.
 	
 	You do NOT have to run this script on a server running RAS. This script was developed 
 	and run from a Windows 10 VM.
@@ -33,12 +33,59 @@
 		Spanish
 		Swedish
 
+.PARAMETER ServerName
+	Specifies which RAS server to use to run the script against.
+	
+	ServerName can be entered as the NetBIOS name, FQDN, localhost, or IP Address.
+	
+	If entered as localhost, the actual computer name is determined and used.
+	
+	If entered as an IP address, an attempt is made to determine and use the actual 
+	computer name.
+	
+	Default value is LocalHost
+.PARAMETER User
+	Username to use for the connection to the RAS server.
+
+	Default value is contained in $env:username
 .PARAMETER HTML
 	Creates an HTML file with an .html extension.
 	
 	HTML is now the default report format.
 	
 	This parameter is set True if no other output format is selected.
+.PARAMETER Text
+	Creates a formatted text file with a .txt extension.
+	
+	This parameter is disabled by default.
+.PARAMETER Folder
+	Specifies the optional output folder to save the output report. 
+.PARAMETER AddDateTime
+	Adds a date timestamp to the end of the file name.
+	
+	The timestamp is in the format of yyyy-MM-dd_HHmm.
+	June 1, 2022 at 6PM is 2022-06-01_1800.
+	
+	Output filename will be ReportName_2022-06-01_1800.<ext>.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of ADT.
+.PARAMETER Dev
+	Clears errors at the beginning of the script.
+	Outputs all errors to a text file at the end of the script.
+	
+	This is used when the script developer requests more troubleshooting data.
+	The text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+.PARAMETER Log
+	Generates a log file for troubleshooting.
+.PARAMETER ScriptInfo
+	Outputs information about the script to a text file.
+	The text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of SI.
 .PARAMETER MSWord
 	SaveAs DOCX file
 	
@@ -53,20 +100,6 @@
 	This parameter uses Word's SaveAs PDF capability.
 
 	This parameter is disabled by default.
-.PARAMETER Text
-	Creates a formatted text file with a .txt extension.
-	
-	This parameter is disabled by default.
-.PARAMETER AddDateTime
-	Adds a date timestamp to the end of the file name.
-	
-	The timestamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2019 at 6PM is 2021-06-01_1800.
-	
-	Output filename will be ReportName_2021-06-01_1800.<ext>.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of ADT.
 .PARAMETER CompanyAddress
 	Company Address to use for the Cover Page, if the Cover Page has the Address field.
 	
@@ -84,7 +117,7 @@
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CA.
 .PARAMETER CompanyEmail
-	Company Email to use for the Cover Page, if the Cover Page has the Email field. 
+	Company Email to use for the Cover Page if the Cover Page has the Email field. 
 	
 	The following Cover Pages have an Email field:
 		Facet (Word 2013/2016)
@@ -92,7 +125,7 @@
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CE.
 .PARAMETER CompanyFax
-	Company Fax to use for the Cover Page, if the Cover Page has the Fax field. 
+	Company Fax to use for the Cover Page if the Cover Page has the Fax field. 
 	
 	The following Cover Pages have a Fax field:
 		Contrast (Word 2010)
@@ -120,7 +153,7 @@
 	This parameter has an alias of CPh.
 .PARAMETER CoverPage
 	What Microsoft Word Cover Page to use.
-	Only Word 2010, 2013 and 2016 are supported.
+	Only Word 2010, 2013, and 2016 are supported.
 	(default cover pages in Word en-US)
 
 	Valid input is:
@@ -166,39 +199,11 @@
 	The default value is Sideline.
 	This parameter has an alias of CP.
 	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER Dev
-	Clears errors at the beginning of the script.
-	Outputs all errors to a text file at the end of the script.
-	
-	This is used when the script developer requests more troubleshooting data.
-	The text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-.PARAMETER Folder
-	Specifies the optional output folder to save the output report. 
-.PARAMETER From
-	Specifies the username for the From email address.
-	
-	If SmtpServer or To are used, this is a required parameter.
-.PARAMETER Log
-	Generates a log file for troubleshooting.
-.PARAMETER ScriptInfo
-	Outputs information about the script to a text file.
-	The text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of SI.
-.PARAMETER ServerName
-	Specifies which RAS server to use to run the script against.
-	
-	ServerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
-	
-	If entered as localhost, the actual computer name is determined and used.
-	
-	If entered as an IP address, an attempt is made to determine and use the actual 
-	computer name.
-	
-	Default value is LocalHost
+.PARAMETER UserName
+	Username to use for the Cover Page and Footer.
+	The default value is contained in $env:username
+	This parameter has an alias of UN.
+	This parameter is only valid with the MSWORD and PDF output parameters.
 .PARAMETER SmtpPort
 	Specifies the SMTP port for the SmtpServer. 
 	The default is 25.
@@ -206,19 +211,14 @@
 	Specifies the optional email server to send the output report(s). 
 	
 	If From or To are used, this is a required parameter.
+.PARAMETER From
+	Specifies the username for the From email address.
+	
+	If SmtpServer or To are used, this is a required parameter.
 .PARAMETER To
 	Specifies the username for the To email address.
 	
 	If SmtpServer or From are used, this is a required parameter.
-.PARAMETER User
-	Username to use for the connection to the RAS server.
-
-	Default value is contained in $env:username
-.PARAMETER UserName
-	Username to use for the Cover Page and Footer.
-	The default value is contained in $env:username
-	This parameter has an alias of UN.
-	This parameter is only valid with the MSWORD and PDF output parameters.
 .PARAMETER UseSSL
 	Specifies whether to use SSL for the SmtpServer.
 	The default is False.
@@ -387,21 +387,40 @@
 
 Param(
 	[parameter(Mandatory=$False)] 
+	[string]$ServerName="LocalHost",
+	
+	[parameter(Mandatory=$False)] 
+	[string]$User=$env:username,
+	
+	[parameter(Mandatory=$False)] 
 	[Switch]$HTML=$False,
 
+	[parameter(Mandatory=$False)] 
+	[Switch]$Text=$False,
+
+	[parameter(Mandatory=$False)] 
+	[string]$Folder="",
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("ADT")]
+	[Switch]$AddDateTime=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Dev=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Log=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SI")]
+	[Switch]$ScriptInfo=$False,
+	
 	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
 	[Switch]$MSWord=$False,
 
 	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
 	[Switch]$PDF=$False,
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$Text=$False,
-
-	[parameter(Mandatory=$False)] 
-	[Alias("ADT")]
-	[Switch]$AddDateTime=$False,
-	
 	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
 	[Alias("CA")]
 	[ValidateNotNullOrEmpty()]
@@ -432,25 +451,11 @@ Param(
 	[ValidateNotNullOrEmpty()]
 	[string]$CoverPage="Sideline", 
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$Dev=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[string]$Folder="",
-	
-	[parameter(Mandatory=$False)] 
-	[string]$From="",
+	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
+	[Alias("UN")]
+	[ValidateNotNullOrEmpty()]
+	[string]$UserName=$env:username,
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$Log=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("SI")]
-	[Switch]$ScriptInfo=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[string]$ServerName="LocalHost",
-	
 	[parameter(Mandatory=$False)] 
 	[int]$SmtpPort=25,
 
@@ -458,12 +463,7 @@ Param(
 	[string]$SmtpServer="",
 
 	[parameter(Mandatory=$False)] 
-	[string]$User=$env:username,
-	
-	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
-	[Alias("UN")]
-	[ValidateNotNullOrEmpty()]
-	[string]$UserName=$env:username,
+	[string]$From="",
 
 	[parameter(Mandatory=$False)] 
 	[string]$To="",
@@ -482,10 +482,13 @@ Param(
 #Version 1.0 released to the community on 5-August-2020
 #
 #Version 1.01 19-Apr-2021
+#	Added a message to the error message for the missing RAS module
+#		Added a link to the V1 ReadMe file
 #	Added the missing License section for published RDSH applications to Text and HTML output
 #	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
 #	Changed the font size of Word/PDF tables from 11 to 10 to prevent most word wrapping to multiple lines
 #	Fixed several invalid $Null comparisons
+#	Reorder Parameters in an order recommended by Guy Leech
 #	Updated Function SetWordCellFormat to the latest version
 #	Updated the ReadMe file
 
@@ -3495,7 +3498,13 @@ Function ProcessScriptSetup
 		The PSAdmin module could not be loaded.
 		`n`n
 		`t`t
+		Are you running this script against a V17 RAS server?
+		`n`n
+		`t`t
 		Please see the Prerequisites section in the ReadMe file (RAS_Inventory_V1_ReadMe.rtf).
+		`n`n
+		`t`t
+		https://carlwebster.sharefile.com/d-safd2a2d3b45f401f8b9678f2a1730f42
 		`n`n
 		`t`t
 		Script cannot continue.

--- a/RAS_Inventory_V1_ReadMe.rtf
+++ b/RAS_Inventory_V1_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -103,14 +103,15 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel
 \listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}{\listoverride\listid2008440808\listoverridecount0\ls6}{\listoverride\listid1250626038\listoverridecount0\ls7}}{\*\pgptbl 
 {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid667579\rsid741398\rsid854968\rsid880017\rsid1206655\rsid1520287\rsid2110091\rsid2313532\rsid2454835\rsid2638156\rsid2710199\rsid2828497\rsid2974686\rsid3342358\rsid3477011\rsid3547319
-\rsid3830441\rsid4281248\rsid4467197\rsid4945864\rsid5117009\rsid5767175\rsid5849890\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7016631\rsid7363671\rsid7681868\rsid7695940\rsid8013811\rsid8284628\rsid8726130\rsid8793422\rsid9122125\rsid9138287
-\rsid9186981\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid9915873\rsid10101060\rsid10111376\rsid10290913\rsid10374270\rsid10777656\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid11885223\rsid12197314\rsid12343757
-\rsid12481227\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13434991\rsid13725463\rsid13858952\rsid13897747\rsid13987238\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid15822428\rsid16005803\rsid16190354\rsid16670594
-\rsid16740185}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo4\dy19\hr6\min21}{\version51}
-{\edmins893}{\nofpages17}{\nofwords3926}{\nofchars22380}{\nofcharsws26254}{\vern23}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid3830441\rsid4281248\rsid4467197\rsid4546918\rsid4945864\rsid5117009\rsid5767175\rsid5849890\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7016631\rsid7363671\rsid7681868\rsid7695940\rsid8013811\rsid8284628\rsid8726130\rsid8793422\rsid9122125
+\rsid9138287\rsid9186981\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid9899102\rsid9915873\rsid10101060\rsid10111376\rsid10290913\rsid10374270\rsid10777656\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid11885223
+\rsid12197314\rsid12343757\rsid12481227\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13434991\rsid13725463\rsid13858952\rsid13897747\rsid13987238\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid15822428\rsid16005803
+\rsid16190354\rsid16670594\rsid16740185}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
+{\revtim\yr2021\mo4\dy20\hr7\min12}{\version53}{\edmins899}{\nofpages17}{\nofwords3928}{\nofchars22391}{\nofcharsws26267}{\vern23}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKgFAFm+xIItAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKwFABiP35stAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -147,7 +148,7 @@ NOTE: This script requires PowerShell V3 or later.
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid10290913 \page \hich\af43\dbch\af31505\loch\f43 What the Script Documents
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0\afs22 
 \ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 The }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15822428 \hich\af31506\dbch\af31505\loch\f31506 script documents the }{\rtlch\fcs1 \af0\afs22 
-\ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 following items\hich\af31506\dbch\af31505\loch\f31506 :
+\ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 following items:
 \par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10290913 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid2454835\charrsid5117009 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin720\itap0\pararsid2454835 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2454835\charrsid5117009 \hich\af31506\dbch\af31505\loch\f31506 Farm Settings}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid5117009 
@@ -284,7 +285,7 @@ Auditing (Not implemented in PoSH yet)
 \ql \fi-360\li2160\ri0\nowidctlpar\wrapdefault\faauto\ls7\ilvl2\rin0\lin2160\itap0\pararsid10111376 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10111376\charrsid5117009 \hich\af31506\dbch\af31505\loch\f31506 Information
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Sites
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Virtual Desktop
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Filtering
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Filterin\hich\af31506\dbch\af31505\loch\f31506 g
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Shortcuts
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f2\fs22\insrsid10111376\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar
 \ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls7\ilvl1\rin0\lin1440\itap0\pararsid10111376 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10111376\charrsid5117009 \hich\af31506\dbch\af31505\loch\f31506 Type = PCApp
@@ -368,7 +369,7 @@ Before we can start using PowerShell to document any\hich\af37\dbch\af31505\loch
 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 Parallels }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 RAS}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 
 \hich\af37\dbch\af31505\loch\f37  server}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 2.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 
-Select the Server or Desktop \hich\af37\dbch\af31505\loch\f37 OS computer/VM for running this script.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 
+Select the Server or Desktop \hich\af37\dbch\af31505\loch\f37 OS computer/VM for running this script.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid7016631\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Install the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 RAS }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 PowerShell module.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
@@ -377,8 +378,8 @@ Select the Server or Desktop \hich\af37\dbch\af31505\loch\f37 OS computer/VM for
 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631\charrsid7016631 \hich\af37\dbch\af31505\loch\f37 https://www.parallels.com/products/ras/download/links/}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1206655 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b86000000680074007400700073003a002f002f007700770077002e0070006100720061006c006c0065006c0073002e0063006f006d002f00700072006f00640075006300740073002f007200610073002f0064006f00
-77006e006c006f00610064002f006c0069006e006b0073002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300004100000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid7016631\charrsid16190354 \hich\af37\dbch\af31505\loch\f37 
-https://www.parallels.com/pr\hich\af37\dbch\af31505\loch\f37 oducts/ras/download/links/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 
+77006e006c006f00610064002f006c0069006e006b0073002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000410000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid7016631\charrsid16190354 
+\hich\af37\dbch\af31505\loch\f37 https://www.parallels.com/products/ras/download/links/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 There are two ways to install just the PowerShell module.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9186981\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 \hich\af37\dbch\af31505\loch\f37 
@@ -9749,7 +9750,7 @@ d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de
 d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418000000040000002701ffff030000000000}}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid9138287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 \hich\af37\dbch\af31505\loch\f37 Deselect every option except }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\i\f37\fs22\insrsid9186981\charrsid9186981 \hich\af37\dbch\af31505\loch\f37 Parallels RAS PowerShell}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 .
+\i\f37\fs22\insrsid9186981\charrsid9186981 \hich\af37\dbch\af31505\loch\f37 Parallels RAS Power\hich\af37\dbch\af31505\loch\f37 Shell}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 .
 \par }\pard \ltrpar\s17\ql \li2160\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin2160\itap0\pararsid9138287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 {\*\shppict
 {\pict{\*\picprop\shplid1026{\sp{\sn shapeType}{\sv 75}}{\sp{\sn fFlipH}{\sv 0}}{\sp{\sn fFlipV}{\sv 0}}{\sp{\sn pibFlags}{\sv 2}}{\sp{\sn fLine}{\sv 0}}{\sp{\sn fLayoutInCell}{\sv 1}}{\sp{\sn fLayoutInCell}{\sv 1}}}
 \picscalex77\picscaley77\piccropl0\piccropr0\piccropt0\piccropb0\picw13099\pich10241\picwgoal7426\pichgoal5806\pngblip\bliptag1151551143{\*\blipuid 44a346a73b2590d690cdaa7b80496bbd}
@@ -19016,8 +19017,7 @@ d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de
 d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418000000040000002701ffff030000000000}}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9138287 \hich\af37\dbch\af31505\loch\f37 b.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9138287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9138287 \hich\af37\dbch\af31505\loch\f37 Open an elevated command prompt.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9138287 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 Change to the folder \hich\af37\dbch\af31505\loch\f37 containing the RAS installer.
-
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9138287 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 Change to the folder containing the RAS installer.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid8284628 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid8284628\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8284628 \hich\af37\dbch\af31505\loch\f37 Type in the following command: }{\rtlch\fcs1 \af2\afs22 
 \ltrch\fcs0 \b\f2\fs22\insrsid8284628\charrsid8284628 \hich\af2\dbch\af31505\loch\f2 msiexec /i RASInstaller-x.y.z.msi /qn ADDLOCAL=F_PowerShell}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8284628 \hich\af37\dbch\af31505\loch\f37 
@@ -20869,8 +20869,8 @@ a500894c00006ca5c00000002b002b000000c0a56c00a56c2b00c0c0c0004c89c000004c89006c2b
 020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020000040000002701ffff030000000000}}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid8284628\charrsid9186981 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\par \hich\af37\dbch\af31505\loch\f37 This script was developed using }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 RAS 1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5117009 
-\hich\af37\dbch\af31505\loch\f37 7.1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10777656 \hich\af37\dbch\af31505\loch\f37  running on Windows Server 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5117009 
+\par \hich\af37\dbch\af31505\loch\f37 This script was developed using\hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 RAS 1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid5117009 \hich\af37\dbch\af31505\loch\f37 7.1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10777656 \hich\af37\dbch\af31505\loch\f37  running on Windows Server 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5117009 
 \hich\af37\dbch\af31505\loch\f37 9}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10777656 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 and PowerShell Version }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10777656 
 \hich\af37\dbch\af31505\loch\f37 1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 . The script was run on Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 
@@ -20896,10 +20896,10 @@ a500894c00006ca5c00000002b002b000000c0a56c00a56c2b00c0c0c0004c89c000004c89006c2b
 \rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{
 \rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 4.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 B\hich\af37\dbch\af31505\loch\f37 y default, }{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a}{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37 n HTML file }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37 Parallels_RAS.html}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 By default, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37 n HTML file }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 
+\hich\af37\dbch\af31505\loch\f37 Parallels_RAS.html}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 PDF option, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 
@@ -20908,9 +20908,9 @@ named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 6.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid6095241\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37 MSWord}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 the sc\hich\af37\dbch\af31505\loch\f37 ript creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a}{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 DOC\hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37  file }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 
+\f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 DOCX}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 
+\hich\af37\dbch\af31505\loch\f37  file }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 
 \hich\af37\dbch\af31505\loch\f37 Parallels_RAS.docx}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 7.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 
@@ -20936,7 +20936,8 @@ named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37
 \par \hich\af2\dbch\af31505\loch\f2     C:\\RASScript\\RAS_Inventory_V1.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of Parallels Remote Application Server.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 a V17 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 Parallels Remote Application Server.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
@@ -20944,29 +20945,31 @@ named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-C\hich\af2\dbch\af31505\loch\f2 ompanyName <String>] [-CompanyPhone <String>] [-CoverPage}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
+
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 <String>] [-From <String>] [-Log] [-ScriptInfo] [-ServerName <String>] [-SmtpPort}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     <Int32>] [-SmtpServer <String>] [-User <String>] [-UserName <String>] [-To <Stri\hich\af2\dbch\af31505\loch\f2 ng>] }{\rtlch\fcs1 \af2\afs18 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     <Int32>] [-SmtpServer <S\hich\af2\dbch\af31505\loch\f2 tring>] [-User <String>] [-UserName <String>] [-To <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-UseSSL] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of Parallels Remote Application Server (RAS) using
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 a V17 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 Parallels Remote Application Server (RAS) using
 \par \hich\af2\dbch\af31505\loch\f2     Microsoft PowerShell, Word, plain text, or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script requires at least PowerShell version 3 but runs \hich\af2\dbch\af31505\loch\f2 best in version 5.
+\par \hich\af2\dbch\af31505\loch\f2     The\hich\af2\dbch\af31505\loch\f2  script requires at least PowerShell version 3 but runs best in version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script output}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2110091 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  in Text and HTML.
 \par \hich\af2\dbch\af31505\loch\f2     The default output format is HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named RASInventory.<fileextension>.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 Parallels_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 RAS\hich\af2\dbch\af31505\loch\f2 .<fileextension\hich\af2\dbch\af31505\loch\f2 >.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a server r\hich\af2\dbch\af31505\loch\f2 unning RAS. This script was developed
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a server running RAS. This script was developed
 \par \hich\af2\dbch\af31505\loch\f2     and run from a Windows 10 VM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2110091 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
@@ -20978,12 +20981,12 @@ named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
-\par \hich\af2\dbch\af31505\loch\f2         French
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
 \par \hich\af2\dbch\af31505\loch\f2         Spanish
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Swedish
+\par \hich\af2\dbch\af31505\loch\f2         Swedish
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
@@ -20992,9 +20995,9 @@ named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         HTML is now the default report format.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
+\par \hich\af2\dbch\af31505\loch\f2         This param\hich\af2\dbch\af31505\loch\f2 eter is set True if no other output format is selected.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?      \hich\af2\dbch\af31505\loch\f2               false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -21008,51 +21011,53 @@ named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value            \hich\af2\dbch\af31505\loch\f2     False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF file instead of DOCX file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This \hich\af2\dbch\af31505\loch\f2 parameter requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Defa\hich\af2\dbch\af31505\loch\f2 ult value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Cr\hich\af2\dbch\af31505\loch\f2 eates a formatted text file with a .txt extension.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is d\hich\af2\dbch\af31505\loch\f2 isabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inp\hich\af2\dbch\af31505\loch\f2 ut?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2019 at 6PM is 2021-06-0\hich\af2\dbch\af31505\loch\f2 1_1800.
+\par \hich\af2\dbch\af31505\loch\f2         The tim\hich\af2\dbch\af31505\loch\f2 estamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 20}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 22}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is 202}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2021-06-01_1800.<ext>.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_202}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 -06-01_1800.<ext>.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -21080,29 +21085,29 @@ named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page\hich\af2\dbch\af31505\loch\f2  if the Cover Page has the Email field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
-\par \hich\af2\dbch\af31505\loch\f2                 Fa\hich\af2\dbch\af31505\loch\f2 cet (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax fi\hich\af2\dbch\af31505\loch\f2 eld.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page\hich\af2\dbch\af31505\loch\f2  if the Cover Page has the \hich\af2\dbch\af31505\loch\f2 Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias o\hich\af2\dbch\af31505\loch\f2 f CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -21111,32 +21116,32 @@ named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for th\hich\af2\dbch\af31505\loch\f2 e Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  on the computer running the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages\hich\af2\dbch\af31505\loch\f2  have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a\hich\af2\dbch\af31505\loch\f2  Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                  \hich\af2\dbch\af31505\loch\f2   false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -21144,94 +21149,95 @@ named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4546918 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  and 2016 are supported.
+
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
-\par \hich\af2\dbch\af31505\loch\f2                 Aust\hich\af2\dbch\af31505\loch\f2 ere (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't \hich\af2\dbch\af31505\loch\f2 work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
  but Subtitle/Subject & Author fields need }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 moving }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
-after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 the\hich\af2\dbch\af31505\loch\f2  
-\par \hich\af2\dbch\af31505\loch\f2                 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 title box is moved up)
-\par \hich\af2\dbch\af31505\loch\f2                 Banded\hich\af2\dbch\af31505\loch\f2  (Word 2013/2016. Works)
+after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 the 
+\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
-\par \hich\af2\dbch\af31505\loch\f2                 Facet \hich\af2\dbch\af31505\loch\f2 (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if y\hich\af2\dbch\af31505\loch\f2 ou like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs \hich\af2\dbch\af31505\loch\f2 to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (\hich\af2\dbch\af31505\loch\f2 Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 poin\hich\af2\dbch\af31505\loch\f2 t)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Motion (Word 2010/2013/2016. Works if }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \hich\af2\dbch\af31505\loch\f2 date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word\hich\af2\dbch\af31505\loch\f2  2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (\hich\af2\dbch\af31505\loch\f2 Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 . W}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 orks in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 20\hich\af2\dbch\af31505\loch\f2 13/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 Whisp (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. \hich\af2\dbch\af31505\loch\f2 Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs \hich\af2\dbch\af31505\loch\f2 all errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         T\hich\af2\dbch\af31505\loch\f2 he text file is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder\hich\af2\dbch\af31505\loch\f2  from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    n\hich\af2\dbch\af31505\loch\f2 amed
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept\hich\af2\dbch\af31505\loch\f2  pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a required parame\hich\af2\dbch\af31505\loch\f2 ter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                  \hich\af2\dbch\af31505\loch\f2   false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -21244,42 +21250,43 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by\hich\af2\dbch\af31505\loch\f2  default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parame\hich\af2\dbch\af31505\loch\f2 ter has an alias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charac\hich\af2\dbch\af31505\loch\f2 ters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -ServerName <String>
+\par \hich\af2\dbch\af31505\loch\f2     -ServerName\hich\af2\dbch\af31505\loch\f2  <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies which RAS server to use to run the script against.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         ServerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         ServerName can be entered as the NetBIOS name, FQDN, localhost}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4546918 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2  or IP Address.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is\hich\af2\dbch\af31505\loch\f2  determined and used.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
 \par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default value is LocalHost
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?        \hich\af2\dbch\af31505\loch\f2             false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port for the SmtpServer.
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    The default is 25.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port for the\hich\af2\dbch\af31505\loch\f2  SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -21287,7 +21294,7 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <Str\hich\af2\dbch\af31505\loch\f2 ing>
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report(s).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If From or To are used, this is a required parameter.
@@ -21301,16 +21308,16 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2     -User <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the connection to the RAS server.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Default value \hich\af2\dbch\af31505\loch\f2 is contained in $env:username
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Username to u\hich\af2\dbch\af31505\loch\f2 se for the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
@@ -21327,46 +21334,46 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or From are used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?      \hich\af2\dbch\af31505\loch\f2               named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supp\hich\af2\dbch\af31505\loch\f2 orts the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft\hich\af2\dbch\af31505\loch\f2 
+.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000f}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216
-}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000fbe}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
+https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are o\hich\af2\dbch\af31505\loch\f2 utput from this script. This script creates a Word, PDF, HTML, or plain
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script. This script creates a Word, PDF, HTML, or plain
 \par \hich\af2\dbch\af31505\loch\f2     text document.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: RAS_Inventory_V1.ps1
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13897747 \hich\af2\dbch\af31505\loch\f2 1.01}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl \hich\af2\dbch\af31505\loch\f2 Webster
 \par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13897747 \hich\af2\dbch\af31505\loch\f2 April 19, 202}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2110091 \hich\af2\dbch\af31505\loch\f2 1}{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------------\hich\af2\dbch\af31505\loch\f2 ------------ EXAMPLE 1 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1
 \par 
@@ -21376,7 +21383,7 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\RAS_Inventory_V1.ps1 -MSWord -CompanyName "Carl Webster }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{
@@ -21384,12 +21391,12 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the C\hich\af2\dbch\af31505\loch\f2 over Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         RAS server named RAS01 for the ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs to Microsoft Word.
-\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the RAS Server RAS01.
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the RA\hich\af2\dbch\af31505\loch\f2 S Server RAS01.
 \par 
 \par 
 \par 
@@ -21401,7 +21408,7 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (\hich\af2\dbch\af31505\loch\f2 alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         C\hich\af2\dbch\af31505\loch\f2 arl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par 
@@ -21411,7 +21418,7 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------------\hich\af2\dbch\af31505\loch\f2 -------------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\RAS_Inventory_V1.ps1 -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
@@ -21426,13 +21433,13 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. \hich\af2\dbch\af31505\loch\f2 Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs to Microsoft Word.
-\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials\hich\af2\dbch\af31505\loch\f2  for the Local}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 h}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the Lo\hich\af2\dbch\af31505\loch\f2 cal}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 h}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 ost RAS Server.
 \par 
 \par 
@@ -21444,8 +21451,8 @@ after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\db
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -UserName "Dr. Watson"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -Com\hich\af2\dbch\af31505\loch\f2 panyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 
-SuperSleuth@SherlockHolmes.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -CompanyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@S\hich\af2\dbch\af31505\loch\f2 
+herlockHolmes.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
@@ -21474,14 +21481,13 @@ ITGroup@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
  the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\hich\af2\dbch\af31505\loch\f2  the d\hich\af2\dbch\af31505\loch\f2 efault SMTP port 25 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 does }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the default SMTP port 25 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 does }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials a\hich\af2\dbch\af31505\loch\f2 re not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 email,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 script prompts 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 the \hich\af2\dbch\af31505\loch\f2 user }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     the user }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs to a text file.
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the Local}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 h}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
@@ -21492,16 +21498,16 @@ ITGroup@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\hich\af2\dbch\af31505\loch\f2 -SmtpServer mailrelay.domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 PS C:\\PSScript >.\\RAS_Inventory_V1.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -SmtpServer mailrelay.domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 Anonymous@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  The script \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  the email server mailrelay.domain.tld, sending from
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the email server mailrelay.domain.tld, sending from
 \par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
@@ -21509,20 +21515,19 @@ unauthenticated email using an email relay server requires the From email }{\rtl
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 account}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 to use the name Anonymous.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\hich\af2\dbch\af31505\loch\f2  the default SMTP port 25 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 does}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\hich\af2\dbch\af31505\loch\f2  not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the default SMTP port 25 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 does}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8726130 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003304600}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003304600a9}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid8726130 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003440734}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003440734c2}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
@@ -21530,10 +21535,10 @@ email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af
 \hich\af2\dbch\af31505\loch\f2 the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 secure app access" option on your account.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G S\hich\af2\dbch\af31505\loch\f2 UITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 generate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  an anonymous}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+\par \hich\af2\dbch\af31505\loch\f2     The script generate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2  an anonymous}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
  secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
@@ -21547,34 +21552,33 @@ email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \hich\af2\dbch\af31505\loch\f2 -SmtpServer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 l}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 abaddomain-com.mail.protection.outlook.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -UseSSL}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     l}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 abaddomain-com.mail.protection.outlook.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -UseSSL}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 SomeEmailAddress@labaddomain.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https:/\hich\af2\dbch\af31505\loch\f2 
-/docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000074000e}}}{\fldrslt {
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
-https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009\charrsid5117009 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000074000e30}}}{\fldrslt {
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practice\hich\af2\dbch\af31505\loch\f2 
+s/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\hich\af2\dbch\af31505\loch\f2  the email server labaddomain-com.mail.protection.outlook.com,
-\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the email server labaddomain-com.mail.protection.outlook.com,
+\par \hich\af2\dbch\af31505\loch\f2     sending \hich\af2\dbch\af31505\loch\f2 from SomeEmailAddress@labaddomain.com, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 sending to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   The script \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  the default SMTP port 25 and \hich\af2\dbch\af31505\loch\f2 SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the default SMTP port 25 and SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost RAS Server.
@@ -21582,7 +21586,7 @@ https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------------\hich\af2\dbch\af31505\loch\f2 ------------ EXAMPLE 9 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \hich\af2\dbch\af31505\loch\f2 -SmtpServer smtp.office365.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
@@ -21591,17 +21595,16 @@ https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 Webster@CarlWebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The scri\hich\af2\dbch\af31505\loch\f2 pt \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  the email server smtp.office365.com on port 587 using SSL,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the email server smtp.office365.com on port 587 using SSL,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \hich\af2\dbch\af31505\loch\f2 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 email,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 script prompts 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 user \hich\af2\dbch\af31505\loch\f2 to enter 
-\hich\af2\dbch\af31505\loch\f2 valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 user to enter \hich\af2\dbch\af31505\loch\f2 valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost RAS Server.
@@ -21625,9 +21628,9 @@ email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 secure app access" op\hich\af2\dbch\af31505\loch\f2 tion on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script \hich\af2\dbch\af31505\loch\f2 use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\hich\af2\dbch\af31505\loch\f2  the email server smtp.gmail.com on port 587 using SSL,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the email server smtp.gmail.com on port 587 using SSL,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 webster@gmail.com, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 
 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@carlwebster.com.
 \par 
@@ -21635,8 +21638,7 @@ and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009
     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 
 \hich\af2\dbch\af31505\loch\f2 email,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 the }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 script prompts 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 user \hich\af2\dbch\af31505\loch\f2 to enter 
-\hich\af2\dbch\af31505\loch\f2 valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 user to enter valid credentials.
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5117009 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost RAS Server.
@@ -21762,8 +21764,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000a0c3
-a0200e35d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000809f
+8a63de35d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/RAS_Script_ChangeLog.txt
+++ b/RAS_Script_ChangeLog.txt
@@ -6,9 +6,12 @@
 #Version 1.0 released to the community on 5-August-2020
 #
 #Version 1.01 19-Apr-2021
+#	Added a message to the error message for the missing RAS module
+#		Added a link to the V1 ReadMe file
 #	Added the missing License section for published RDSH applications to Text and HTML output
 #	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
 #	Changed the font size of Word/PDF tables from 11 to 10 to prevent most word wrapping to multiple lines
 #	Fixed several invalid $Null comparisons
+#	Reorder Parameters in an order recommended by Guy Leech
 #	Updated Function SetWordCellFormat to the latest version
 #	Updated the ReadMe file

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # ParallelsRAS
 Parallels Remote Application Server Documentation Script
 
-	Creates a complete inventory of Parallels Remote Application Server (RAS) using 
+	Creates a complete inventory of a V17 Parallels Remote Application Server (RAS) using 
 	Microsoft PowerShell, Word, plain text, or HTML.
 	
 	The script requires at least PowerShell version 3 but runs best in version 5.
 
-	Word is NOT needed to run the script. This script will output in Text and HTML.
+	Word is NOT needed to run the script. This script outputs in Text and HTML.
 	The default output format is HTML.
 	
-	Creates an output file named RASInventory.<fileextension>.
+	Creates an output file named Parallels_RAS.<fileextension>.
 	
 	You do NOT have to run this script on a server running RAS. This script was developed 
 	and run from a Windows 10 VM.
 
-	Word and PDF document includes a Cover Page, Table of Contents and Footer.
+	Word and PDF document includes a Cover Page, Table of Contents, and Footer.
 	Includes support for the following language versions of Microsoft Word:
 		Catalan
 		Chinese
@@ -28,3 +28,4 @@ Parallels Remote Application Server Documentation Script
 		Portuguese
 		Spanish
 		Swedish
+


### PR DESCRIPTION
#Version 1.01 19-Apr-2021
#	Added a message to the error message for the missing RAS module
#		Added a link to the V1 ReadMe file
#	Added the missing License section for published RDSH applications to Text and HTML output
#	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
#	Changed the font size of Word/PDF tables from 11 to 10 to prevent most word wrapping to multiple lines
#	Fixed several invalid $Null comparisons
#	Reorder Parameters in an order recommended by Guy Leech
#	Updated Function SetWordCellFormat to the latest version
#	Updated the ReadMe file